### PR TITLE
phase-3: resume in internal player (VOD+Series)

### DIFF
--- a/app/src/main/java/com/chris/m3usuite/player/InternalPlayerScreen.kt
+++ b/app/src/main/java/com/chris/m3usuite/player/InternalPlayerScreen.kt
@@ -327,47 +327,7 @@ fun InternalPlayerScreen(
         }
     )
 }
-
-private fun saveResume(
-    db: AppDatabase,
-    type: String,
-    mediaId: Long?,
-    episodeId: Int?,
-    posMs: Long
-) {
-    if (type == "live") return // Live nicht persistieren
-    val pos = (posMs / 1000).toInt().coerceAtLeast(0)
-    when {
-        type == "vod" && mediaId != null -> {
-            runBlocking {
-                db.resumeDao().upsert(
-                    ResumeMark(
-                        type = "vod",
-                        mediaId = mediaId,
-                        episodeId = null,
-                        positionSecs = pos,
-                        updatedAt = System.currentTimeMillis()
-                    )
-                )
-            }
-        }
-        type == "series" && episodeId != null -> {
-            runBlocking {
-                db.resumeDao().upsert(
-                    ResumeMark(
-                        type = "series",
-                        mediaId = null,
-                        episodeId = episodeId,
-                        positionSecs = pos,
-                        updatedAt = System.currentTimeMillis()
-                    )
-                )
-            }
-        }
-        else -> Unit
-    }
-}
-
+// helper: apply opacity to ARGB color
 private fun withOpacity(argb: Int, percent: Int): Int {
     val p = percent.coerceIn(0, 100)
     val a = (p / 100f * 255f).toInt().coerceIn(0, 255)

--- a/app/src/main/java/com/chris/m3usuite/player/InternalPlayerScreen.kt
+++ b/app/src/main/java/com/chris/m3usuite/player/InternalPlayerScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -29,6 +30,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.exoplayer.ExoPlayer
@@ -38,14 +40,17 @@ import com.chris.m3usuite.data.db.AppDatabase
 import com.chris.m3usuite.data.db.DbProvider
 import com.chris.m3usuite.data.db.ResumeMark
 import com.chris.m3usuite.prefs.SettingsStore
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 
 /**
  * Interner Player (Media3) mit:
  * - Untertitel-Stil aus Settings
- * - Resume-Speicherung alle 2s & beim Schließen
+ * - Resume-Speicherung alle ~3s & beim Schließen
  * - optionaler Startposition
  *
  * type: "vod" | "series" | "live"  (live wird nicht persistiert)
@@ -63,6 +68,7 @@ fun InternalPlayerScreen(
 ) {
     val ctx = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
+    val scope = rememberCoroutineScope()
 
     val db: AppDatabase = remember(ctx) { DbProvider.get(ctx) }
     val store = remember(ctx) { SettingsStore(ctx) }
@@ -100,14 +106,66 @@ fun InternalPlayerScreen(
             }
     }
 
-    // Lifecycle: Pause/Resume/Release
+    // resume: load (seek to saved position if available and >10s)
+    LaunchedEffect(type, mediaId, episodeId, exoPlayer) {
+        if ((type == "vod" && mediaId != null) || (type == "series" && episodeId != null)) {
+            try {
+                if (startPositionMs == null) {
+                    val posSecs = withContext(Dispatchers.IO) {
+                        val dao = db.resumeDao()
+                        val mark = if (type == "vod") dao.getVod(mediaId ?: -1) else dao.getEpisode(episodeId ?: -1)
+                        mark?.positionSecs
+                    }
+                    val p = (posSecs ?: 0)
+                    if (p > 10) {
+                        exoPlayer.seekTo(p.toLong() * 1000L)
+                    }
+                }
+            } catch (_: Throwable) {
+                // ignore, best-effort
+            }
+        }
+    }
+
+    // Lifecycle: Pause/Resume/Release + resume: clear/save on destroy
     DisposableEffect(lifecycleOwner, exoPlayer) {
         val obs = LifecycleEventObserver { _, event ->
             when (event) {
                 Lifecycle.Event.ON_PAUSE -> exoPlayer.playWhenReady = false
                 Lifecycle.Event.ON_RESUME -> exoPlayer.playWhenReady = true
                 Lifecycle.Event.ON_DESTROY -> {
-                    runBlocking { saveResume(db, type, mediaId, episodeId, exoPlayer.currentPosition) }
+                    // resume: clear if near end (<10s), otherwise save
+                    runBlocking {
+                        try {
+                            if (type != "live") {
+                                val dur = exoPlayer.duration
+                                val pos = exoPlayer.currentPosition
+                                val remaining = if (dur > 0) dur - pos else Long.MAX_VALUE
+                                if ((type == "vod" && mediaId != null) || (type == "series" && episodeId != null)) {
+                                    if (dur > 0 && remaining in 0..9999) {
+                                        withContext(Dispatchers.IO) {
+                                            val dao = db.resumeDao()
+                                            if (type == "vod") dao.clearVod(mediaId!!) else dao.clearEpisode(episodeId!!)
+                                        }
+                                    } else {
+                                        withContext(Dispatchers.IO) {
+                                            val dao = db.resumeDao()
+                                            val posSecs = (pos / 1000L).toInt().coerceAtLeast(0)
+                                            val mark = ResumeMark(
+                                                type = if (type == "vod") "vod" else "series",
+                                                mediaId = if (type == "vod") mediaId else null,
+                                                episodeId = if (type == "series") episodeId else null,
+                                                positionSecs = posSecs,
+                                                updatedAt = System.currentTimeMillis()
+                                            )
+                                            dao.upsert(mark)
+                                        }
+                                    }
+                                }
+                            }
+                        } catch (_: Throwable) {
+                        }
+                    }
                     exoPlayer.release()
                 }
                 else -> Unit
@@ -131,16 +189,93 @@ fun InternalPlayerScreen(
         }
     }
 
-    // Periodisch speichern (live wird in saveResume() ignoriert)
+    // resume: save/clear periodically (~3s)
     LaunchedEffect(url, type, mediaId, episodeId, exoPlayer) {
         while (isActive) {
-            saveResume(db, type, mediaId, episodeId, exoPlayer.currentPosition)
-            delay(2000)
+            try {
+                if ((type == "vod" && mediaId != null) || (type == "series" && episodeId != null)) {
+                    val dur = exoPlayer.duration
+                    val pos = exoPlayer.currentPosition
+                    val remaining = if (dur > 0) dur - pos else Long.MAX_VALUE
+                    if (dur > 0 && remaining in 0..9999) {
+                        withContext(Dispatchers.IO) {
+                            val dao = db.resumeDao()
+                            if (type == "vod") dao.clearVod(mediaId!!) else dao.clearEpisode(episodeId!!)
+                        }
+                    } else if (type != "live") {
+                        val posSecs = (pos / 1000L).toInt().coerceAtLeast(0)
+                        withContext(Dispatchers.IO) {
+                            val dao = db.resumeDao()
+                            val mark = ResumeMark(
+                                type = if (type == "vod") "vod" else "series",
+                                mediaId = if (type == "vod") mediaId else null,
+                                episodeId = if (type == "series") episodeId else null,
+                                positionSecs = posSecs,
+                                updatedAt = System.currentTimeMillis()
+                            )
+                            dao.upsert(mark)
+                        }
+                    }
+                }
+            } catch (_: Throwable) {
+            }
+            delay(3000)
         }
     }
 
+    // resume: clear on playback ended
+    DisposableEffect(exoPlayer, type, mediaId, episodeId) {
+        val listener = object : Player.Listener {
+            override fun onPlaybackStateChanged(playbackState: Int) {
+                if (playbackState == Player.STATE_ENDED) {
+                    if ((type == "vod" && mediaId != null) || (type == "series" && episodeId != null)) {
+                        scope.launch(Dispatchers.IO) {
+                            try {
+                                val dao = db.resumeDao()
+                                if (type == "vod") dao.clearVod(mediaId!!) else dao.clearEpisode(episodeId!!)
+                            } catch (_: Throwable) {}
+                        }
+                    }
+                }
+            }
+        }
+        exoPlayer.addListener(listener)
+        onDispose { exoPlayer.removeListener(listener) }
+    }
+
     fun finishAndRelease() {
-        runBlocking { saveResume(db, type, mediaId, episodeId, exoPlayer.currentPosition) }
+        // resume: clear if near end (<10s), otherwise save
+        runBlocking {
+            try {
+                if (type != "live") {
+                    if ((type == "vod" && mediaId != null) || (type == "series" && episodeId != null)) {
+                        val dur = exoPlayer.duration
+                        val pos = exoPlayer.currentPosition
+                        val remaining = if (dur > 0) dur - pos else Long.MAX_VALUE
+                        if (dur > 0 && remaining in 0..9999) {
+                            withContext(Dispatchers.IO) {
+                                val dao = db.resumeDao()
+                                if (type == "vod") dao.clearVod(mediaId!!) else dao.clearEpisode(episodeId!!)
+                            }
+                        } else {
+                            withContext(Dispatchers.IO) {
+                                val dao = db.resumeDao()
+                                val posSecs = (pos / 1000L).toInt().coerceAtLeast(0)
+                                val mark = ResumeMark(
+                                    type = if (type == "vod") "vod" else "series",
+                                    mediaId = if (type == "vod") mediaId else null,
+                                    episodeId = if (type == "series") episodeId else null,
+                                    positionSecs = posSecs,
+                                    updatedAt = System.currentTimeMillis()
+                                )
+                                dao.upsert(mark)
+                            }
+                        }
+                    }
+                }
+            } catch (_: Throwable) {
+            }
+        }
         exoPlayer.release()
         onExit()
     }


### PR DESCRIPTION
Speichert Wiedergabeposition periodisch, setzt beim Start fort; löscht Markierung am Ende. Live unverändert.