### PR TITLE
Follow-ups: LibraryScreen no-op, manifest cleanup, suppress compileSdk warning

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.chris.m3usuite">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/app/src/main/java/com/chris/m3usuite/ui/screens/LibraryScreen.kt
+++ b/app/src/main/java/com/chris/m3usuite/ui/screens/LibraryScreen.kt
@@ -103,7 +103,7 @@ fun LibraryScreen(
                     store = store,
                     title = { Text("Weiter schauen", style = MaterialTheme.typography.titleMedium) },
                     headerContent = { content() },
-                    contentBelow = { _ -> if (collapsed) Spacer(Modifier.height(0.dp)) }
+                    contentBelow = { _ -> /* nichts zusätzlich */ }
                 )
             }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.suppressUnsupportedCompileSdk=35


### PR DESCRIPTION
Summary\n- LibraryScreen: simplify CollapsibleHeader contentBelow to no-op (aligns with persisted collapse)\n- AndroidManifest: remove root package attribute (use Gradle namespace)\n- gradle.properties: add android.suppressUnsupportedCompileSdk=35 to silence warning on compileSdk 35\n\nScope\n- No behavior changes beyond header persistence flow; no dependency upgrades.\n- No changes under .gradle/.idea/app/build.\n\nBuild\n- Please run ./gradlew build to validate.