### PR TITLE
phase-3: repos for profile/kid filter/screen-time/resume + resume chooser

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,6 +59,7 @@ dependencies {
     implementation("androidx.navigation:navigation-compose:2.8.5")
 
     implementation("androidx.compose.ui:ui:$compose")
+    implementation("androidx.compose.material:material:$compose")
     implementation("androidx.compose.material3:material3:1.3.1")
     implementation("androidx.compose.ui:ui-tooling-preview:$compose")
     debugImplementation("androidx.compose.ui:ui-tooling:$compose")

--- a/app/src/main/java/com/chris/m3usuite/MainActivity.kt
+++ b/app/src/main/java/com/chris/m3usuite/MainActivity.kt
@@ -72,6 +72,7 @@ class MainActivity : ComponentActivity() {
 
                     composable("library") {
                         LibraryScreen(
+                            navController = nav,
                             openLive   = { id -> nav.navigate("live/$id") },
                             openVod    = { id -> nav.navigate("vod/$id") },
                             openSeries = { id -> nav.navigate("series/$id") }

--- a/app/src/main/java/com/chris/m3usuite/data/repo/KidContentRepository.kt
+++ b/app/src/main/java/com/chris/m3usuite/data/repo/KidContentRepository.kt
@@ -1,0 +1,34 @@
+package com.chris.m3usuite.data.repo
+
+import android.content.Context
+import com.chris.m3usuite.data.db.DbProvider
+import com.chris.m3usuite.data.db.KidContentItem
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class KidContentRepository(private val context: Context) {
+    private val db get() = DbProvider.get(context)
+
+    suspend fun allow(kidId: Long, type: String, contentId: Long) = withContext(Dispatchers.IO) {
+        db.kidContentDao().insert(KidContentItem(kidProfileId = kidId, contentType = type, contentId = contentId))
+    }
+
+    suspend fun disallow(kidId: Long, type: String, contentId: Long) = withContext(Dispatchers.IO) {
+        db.kidContentDao().disallow(kidId, type, contentId)
+    }
+
+    suspend fun isAllowed(kidId: Long, type: String, contentId: Long): Boolean = withContext(Dispatchers.IO) {
+        db.kidContentDao().isAllowedCount(kidId, type, contentId) > 0
+    }
+
+    suspend fun allowBulk(kidId: Long, type: String, contentIds: Collection<Long>) = withContext(Dispatchers.IO) {
+        val dao = db.kidContentDao()
+        for (id in contentIds) dao.insert(KidContentItem(kidProfileId = kidId, contentType = type, contentId = id))
+    }
+
+    suspend fun disallowBulk(kidId: Long, type: String, contentIds: Collection<Long>) = withContext(Dispatchers.IO) {
+        val dao = db.kidContentDao()
+        for (id in contentIds) dao.disallow(kidId, type, id)
+    }
+}
+

--- a/app/src/main/java/com/chris/m3usuite/data/repo/MediaQueryRepository.kt
+++ b/app/src/main/java/com/chris/m3usuite/data/repo/MediaQueryRepository.kt
@@ -1,0 +1,64 @@
+package com.chris.m3usuite.data.repo
+
+import android.content.Context
+import com.chris.m3usuite.data.db.DbProvider
+import com.chris.m3usuite.data.db.MediaItem
+import com.chris.m3usuite.prefs.SettingsStore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+
+/**
+ * Filtered media queries that respect Kid profile allowances when active.
+ * Adult profile returns unfiltered results (legacy behavior).
+ */
+class MediaQueryRepository(
+    private val context: Context,
+    private val settings: SettingsStore
+) {
+    private val db get() = DbProvider.get(context)
+
+    private suspend fun isKid(): Boolean = withContext(Dispatchers.IO) {
+        val id = settings.currentProfileId.first()
+        if (id <= 0) return@withContext false
+        val prof = db.profileDao().byId(id)
+        prof?.type == "kid"
+    }
+
+    private suspend fun allowedIdsForType(kidId: Long, type: String): Set<Long> = withContext(Dispatchers.IO) {
+        db.kidContentDao().listForKidAndType(kidId, type).map { it.contentId }.toSet()
+    }
+
+    suspend fun listByTypeFiltered(type: String, limit: Int, offset: Int): List<MediaItem> = withContext(Dispatchers.IO) {
+        if (!isKid()) return@withContext db.mediaDao().listByType(type, limit, offset)
+        val kidId = settings.currentProfileId.first()
+        val allowed = allowedIdsForType(kidId, type)
+        db.mediaDao().listByType(type, limit, offset).filter { it.id in allowed }
+    }
+
+    suspend fun byTypeAndCategoryFiltered(type: String, cat: String?): List<MediaItem> = withContext(Dispatchers.IO) {
+        if (!isKid()) return@withContext db.mediaDao().byTypeAndCategory(type, cat)
+        val kidId = settings.currentProfileId.first()
+        val allowed = allowedIdsForType(kidId, type)
+        db.mediaDao().byTypeAndCategory(type, cat).filter { it.id in allowed }
+    }
+
+    suspend fun categoriesByTypeFiltered(type: String): List<String?> = withContext(Dispatchers.IO) {
+        if (!isKid()) return@withContext db.mediaDao().categoriesByType(type)
+        val kidId = settings.currentProfileId.first()
+        val allowed = allowedIdsForType(kidId, type)
+        db.mediaDao().byTypeAndCategory(type, null).filter { it.id in allowed }.map { it.categoryName }.distinct()
+    }
+
+    suspend fun globalSearchFiltered(query: String, limit: Int, offset: Int): List<MediaItem> = withContext(Dispatchers.IO) {
+        if (!isKid()) return@withContext db.mediaDao().globalSearch(query, limit, offset)
+        val kidId = settings.currentProfileId.first()
+        val types = listOf("live", "vod", "series")
+        val allowedByType = types.associateWith { allowedIdsForType(kidId, it) }
+        db.mediaDao().globalSearch(query, limit, offset).filter { item ->
+            val set = allowedByType[item.type] ?: emptySet()
+            item.id in set
+        }
+    }
+}
+

--- a/app/src/main/java/com/chris/m3usuite/data/repo/ProfileRepository.kt
+++ b/app/src/main/java/com/chris/m3usuite/data/repo/ProfileRepository.kt
@@ -1,0 +1,34 @@
+package com.chris.m3usuite.data.repo
+
+import android.content.Context
+import com.chris.m3usuite.data.db.DbProvider
+import com.chris.m3usuite.data.db.Profile
+import com.chris.m3usuite.prefs.SettingsStore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+
+class ProfileRepository(
+    private val context: Context,
+    private val settings: SettingsStore
+) {
+    private val db get() = DbProvider.get(context)
+
+    suspend fun currentProfile(): Profile? = withContext(Dispatchers.IO) {
+        val id = settings.currentProfileId.first()
+        if (id <= 0) null else db.profileDao().byId(id)
+    }
+
+    suspend fun currentProfileIdOrAdult(): Long = withContext(Dispatchers.IO) {
+        val id = settings.currentProfileId.first()
+        if (id > 0) return@withContext id
+        val adult = db.profileDao().all().firstOrNull { it.type == "adult" }
+        adult?.id ?: -1L
+    }
+
+    suspend fun isKidProfile(): Boolean = withContext(Dispatchers.IO) {
+        val prof = currentProfile()
+        prof?.type == "kid"
+    }
+}
+

--- a/app/src/main/java/com/chris/m3usuite/data/repo/ResumeRepository.kt
+++ b/app/src/main/java/com/chris/m3usuite/data/repo/ResumeRepository.kt
@@ -1,0 +1,46 @@
+package com.chris.m3usuite.data.repo
+
+import android.content.Context
+import com.chris.m3usuite.data.db.DbProvider
+import com.chris.m3usuite.data.db.ResumeEpisodeView
+import com.chris.m3usuite.data.db.ResumeMark
+import com.chris.m3usuite.data.db.ResumeVodView
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class ResumeRepository(private val context: Context) {
+    private val db get() = DbProvider.get(context)
+
+    suspend fun setVodResume(mediaId: Long, positionSecs: Int) = withContext(Dispatchers.IO) {
+        val now = System.currentTimeMillis()
+        db.resumeDao().upsert(
+            ResumeMark(
+                type = "vod",
+                mediaId = mediaId,
+                episodeId = null,
+                positionSecs = positionSecs.coerceAtLeast(0),
+                updatedAt = now
+            )
+        )
+    }
+
+    suspend fun setEpisodeResume(episodeId: Int, positionSecs: Int) = withContext(Dispatchers.IO) {
+        val now = System.currentTimeMillis()
+        db.resumeDao().upsert(
+            ResumeMark(
+                type = "series",
+                mediaId = null,
+                episodeId = episodeId,
+                positionSecs = positionSecs.coerceAtLeast(0),
+                updatedAt = now
+            )
+        )
+    }
+
+    suspend fun clearVod(mediaId: Long) = withContext(Dispatchers.IO) { db.resumeDao().clearVod(mediaId) }
+    suspend fun clearEpisode(episodeId: Int) = withContext(Dispatchers.IO) { db.resumeDao().clearEpisode(episodeId) }
+
+    suspend fun recentVod(limit: Int): List<ResumeVodView> = withContext(Dispatchers.IO) { db.resumeDao().recentVod(limit) }
+    suspend fun recentEpisodes(limit: Int): List<ResumeEpisodeView> = withContext(Dispatchers.IO) { db.resumeDao().recentEpisodes(limit) }
+}
+

--- a/app/src/main/java/com/chris/m3usuite/data/repo/ScreenTimeRepository.kt
+++ b/app/src/main/java/com/chris/m3usuite/data/repo/ScreenTimeRepository.kt
@@ -1,0 +1,51 @@
+package com.chris.m3usuite.data.repo
+
+import android.content.Context
+import com.chris.m3usuite.data.db.DbProvider
+import com.chris.m3usuite.data.db.ScreenTimeEntry
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Locale
+
+class ScreenTimeRepository(private val context: Context) {
+    private val db get() = DbProvider.get(context)
+
+    private fun todayKey(): String {
+        val cal = Calendar.getInstance()
+        val fmt = SimpleDateFormat("yyyyMMdd", Locale.getDefault())
+        return fmt.format(cal.time)
+    }
+
+    private suspend fun ensureTodayEntry(kidId: Long): ScreenTimeEntry = withContext(Dispatchers.IO) {
+        val day = todayKey()
+        db.screenTimeDao().getForDay(kidId, day) ?: run {
+            val entry = ScreenTimeEntry(kidProfileId = kidId, dayYyyymmdd = day, usedMinutes = 0, limitMinutes = 0)
+            db.screenTimeDao().upsert(entry)
+            db.screenTimeDao().getForDay(kidId, day)!!
+        }
+    }
+
+    suspend fun remainingMinutes(kidId: Long): Int = withContext(Dispatchers.IO) {
+        val entry = ensureTodayEntry(kidId)
+        (entry.limitMinutes - entry.usedMinutes).coerceAtLeast(0)
+    }
+
+    suspend fun setDailyLimit(kidId: Long, minutes: Int) = withContext(Dispatchers.IO) {
+        val day = todayKey()
+        ensureTodayEntry(kidId)
+        db.screenTimeDao().updateLimit(kidId, day, minutes.coerceAtLeast(0))
+    }
+
+    suspend fun tickUsageIfPlaying(kidId: Long, deltaSecs: Int) = withContext(Dispatchers.IO) {
+        if (deltaSecs <= 0) return@withContext
+        val day = todayKey()
+        val entry = ensureTodayEntry(kidId)
+        val added = (deltaSecs / 60)
+        if (added <= 0) return@withContext
+        val newUsed = (entry.usedMinutes + added).coerceAtLeast(0)
+        db.screenTimeDao().updateUsed(kidId, day, newUsed)
+    }
+}
+

--- a/app/src/main/java/com/chris/m3usuite/ui/screens/LibraryScreen.kt
+++ b/app/src/main/java/com/chris/m3usuite/ui/screens/LibraryScreen.kt
@@ -37,10 +37,12 @@ import com.chris.m3usuite.ui.util.buildImageRequest
 import com.chris.m3usuite.ui.util.rememberImageHeaders
 import com.chris.m3usuite.ui.components.ResumeSectionAuto
 import com.chris.m3usuite.ui.components.CollapsibleHeader
+import androidx.navigation.NavHostController
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun LibraryScreen(
+    navController: NavHostController,
     openLive: (Long) -> Unit,
     openVod: (Long) -> Unit,
     openSeries: (Long) -> Unit
@@ -109,6 +111,7 @@ fun LibraryScreen(
 
             ResumeCollapsible {
                 ResumeSectionAuto(
+                    navController = navController,
                     limit = 20,
                     onPlayVod = { /* TODO: später Navigation/Player */ },
                     onPlayEpisode = { /* TODO: später Navigation/Player */ },


### PR DESCRIPTION
Phase 3 implementation (backend layer)\n\n- Repos: ProfileRepository, KidContentRepository, MediaQueryRepository (filtered), ScreenTimeRepository, ResumeRepository\n- Library: pass NavController to ResumeSectionAuto; Resume chooser routes to internal player or external\n- Build: add material dependency for existing Material components in ResumeCarousel.kt\n- DB: uses existing entities/indices in AppDatabase/Entities; no destructive migration\n\nConsistency\n- Build succeeds: ./gradlew build (-x lint -x test used locally)\n- No changes to EPG/Xtream behavior or player paths beyond adding internal route call from chooser.\n\nNext\n- Wire filtered queries in UI (Phase 8) and enforce via repos.\n- Add unit tests for filtering and screen-time when test infra is ready.