### PR TITLE
phase-4: player chooser + screen-time gate/tick

### DIFF
--- a/app/src/main/java/com/chris/m3usuite/player/PlayerChooser.kt
+++ b/app/src/main/java/com/chris/m3usuite/player/PlayerChooser.kt
@@ -3,6 +3,7 @@ package com.chris.m3usuite.player
 import android.content.Context
 import kotlinx.coroutines.flow.first
 import com.chris.m3usuite.prefs.SettingsStore
+import com.chris.m3usuite.data.db.DbProvider
 
 /**
  * Zentrale Wahl "Immer fragen | Intern | Extern".
@@ -22,6 +23,20 @@ object PlayerChooser {
         startPositionMs: Long? = null,
         buildInternal: (startPositionMs: Long?) -> Unit
     ) {
+        // Phase 4: Kids immer interner Player
+        val kidForcedInternal = run {
+            val id = store.currentProfileId.first()
+            if (id > 0) {
+                val prof = DbProvider.get(context).profileDao().byId(id)
+                prof?.type == "kid"
+            } else false
+        }
+
+        if (kidForcedInternal) {
+            buildInternal(startPositionMs)
+            return
+        }
+
         when (store.playerMode.first()) {
             "internal" -> buildInternal(startPositionMs)
             "external" -> {


### PR DESCRIPTION
Phase 4 completed\n\n- PlayerChooser: Kids forced to internal; Adults respect player_mode (ask/internal/external)\n- InternalPlayerScreen:\n  - Screen-time gate before start for kids (blocks at 0)\n  - Periodic tickUsageIfPlaying (every ~60s) + stop when limit reached\n  - Global subtitle settings already applied (scale/colors/opacity)\n  - Live not added to resume (existing)\n  - No extra CC/Player UI for kids\n\nBuild: green (no dependency upgrades except existing material dep from Phase 3).