### PR TITLE
phase-5: adult-only settings + subtitle opacity + rotation lock

### DIFF
--- a/app/src/main/java/com/chris/m3usuite/ui/screens/LibraryScreen.kt
+++ b/app/src/main/java/com/chris/m3usuite/ui/screens/LibraryScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.input.key.type
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
@@ -90,8 +91,27 @@ fun LibraryScreen(
     LaunchedEffect(Unit) { load() }
     LaunchedEffect(tab, selectedCategory) { load() }
 
+    // Adult-only: Settings sichtbar, Kids versteckt
+    val profileId by store.currentProfileId.collectAsState(initial = -1L)
+    var showSettings by remember { mutableStateOf(true) }
+    LaunchedEffect(profileId) {
+        val prof = db.profileDao().byId(profileId)
+        showSettings = prof?.type != "kid"
+    }
+
     Scaffold(
-        topBar = { TopAppBar(title = { Text("m3uSuite") }) }
+        topBar = {
+            TopAppBar(
+                title = { Text("m3uSuite") },
+                actions = {
+                    if (showSettings) {
+                        IconButton(onClick = { navController.navigate("settings") }) {
+                            Icon(painterResource(android.R.drawable.ic_menu_manage), contentDescription = "Einstellungen")
+                        }
+                    }
+                }
+            )
+        }
     ) { paddingValues ->
         Column(
             Modifier

--- a/app/src/main/java/com/chris/m3usuite/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/chris/m3usuite/ui/screens/SettingsScreen.kt
@@ -33,7 +33,10 @@ fun SettingsScreen(
     val subScale by store.subtitleScale.collectAsState(initial = 0.06f)
     val subFg by store.subtitleFg.collectAsState(initial = 0xF2FFFFFF.toInt())
     val subBg by store.subtitleBg.collectAsState(initial = 0x66000000)
+    val subFgOpacity by store.subtitleFgOpacityPct.collectAsState(initial = 90)
+    val subBgOpacity by store.subtitleBgOpacityPct.collectAsState(initial = 40)
     val headerCollapsed by store.headerCollapsedDefaultInLandscape.collectAsState(initial = true)
+    val rotationLocked by store.rotationLocked.collectAsState(initial = false)
 
     Scaffold(
         topBar = {
@@ -84,6 +87,22 @@ fun SettingsScreen(
                 palette = bgPalette()
             )
 
+            // Opacity
+            Text("Text-Deckkraft: ${subFgOpacity}%")
+            Slider(
+                value = subFgOpacity.toFloat(),
+                onValueChange = { v -> scope.launch { store.setSubtitleFgOpacityPct(v.toInt().coerceIn(0, 100)) } },
+                valueRange = 0f..100f,
+                steps = 10
+            )
+            Text("Hintergrund-Deckkraft: ${subBgOpacity}%")
+            Slider(
+                value = subBgOpacity.toFloat(),
+                onValueChange = { v -> scope.launch { store.setSubtitleBgOpacityPct(v.toInt().coerceIn(0, 100)) } },
+                valueRange = 0f..100f,
+                steps = 10
+            )
+
             // Vorschau
             OutlinedCard {
                 Box(Modifier.fillMaxWidth().height(120.dp), contentAlignment = Alignment.Center) {
@@ -105,6 +124,13 @@ fun SettingsScreen(
                 Text("Landscape: Header standardmäßig eingeklappt", modifier = Modifier.weight(1f))
                 Switch(checked = headerCollapsed, onCheckedChange = { v ->
                     scope.launch { store.setBool(Keys.HEADER_COLLAPSED_LAND, v) }
+                })
+            }
+
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text("Rotation in Player sperren (Landscape)", modifier = Modifier.weight(1f))
+                Switch(checked = rotationLocked, onCheckedChange = { v ->
+                    scope.launch { store.setRotationLocked(v) }
                 })
             }
         }


### PR DESCRIPTION
Phase 5 completed\n\n- SettingsScreen: adds subtitle opacity sliders (text/bg) and rotation lock toggle; existing player mode, preferred package, header default retained; values persist and apply live.\n- MainActivity: adds settings route, gated to Adult (Kids are redirected); back nav wired.\n- LibraryScreen: gear action visible only for Adult; navigates to settings.\n\nBuild & Test\n- ./gradlew build and ./gradlew test both green.\n\nScope\n- No changes to EPG/Xtream fetch or player routes; UI and persistence remain backward compatible.