### PR TITLE
phase-2: ProfileGate + ProfileManager (kids + limits)

### DIFF
--- a/app/src/main/java/com/chris/m3usuite/MainActivity.kt
+++ b/app/src/main/java/com/chris/m3usuite/MainActivity.kt
@@ -24,6 +24,8 @@ import com.chris.m3usuite.ui.screens.LiveDetailScreen
 import com.chris.m3usuite.ui.screens.PlaylistSetupScreen
 import com.chris.m3usuite.ui.screens.SeriesDetailScreen
 import com.chris.m3usuite.ui.screens.VodDetailScreen
+import com.chris.m3usuite.ui.auth.ProfileGate
+import com.chris.m3usuite.ui.profile.ProfileManagerScreen
 import com.chris.m3usuite.ui.theme.AppTheme
 import com.chris.m3usuite.work.XtreamEnrichmentWorker
 import com.chris.m3usuite.work.XtreamRefreshWorker
@@ -54,7 +56,7 @@ class MainActivity : ComponentActivity() {
                 val m3uUrl = store.m3uUrl.collectAsState(initial = "").value
 
                 // Startziel abhängig von gespeicherter URL
-                val startDestination = if (m3uUrl.isBlank()) "setup" else "library"
+                val startDestination = if (m3uUrl.isBlank()) "setup" else "gate"
 
                 // Worker für Refresh/Enrichment planen, sobald URL vorhanden
                 LaunchedEffect(m3uUrl) {
@@ -74,6 +76,14 @@ class MainActivity : ComponentActivity() {
                                 }
                             }
                         )
+                    }
+
+                    composable("gate") {
+                        ProfileGate(onEnter = {
+                            nav.navigate("library") {
+                                popUpTo("gate") { inclusive = true }
+                            }
+                        })
                     }
 
                     composable("library") {
@@ -156,7 +166,11 @@ class MainActivity : ComponentActivity() {
                                 nav.popBackStack()
                             }
                         }
-                        SettingsScreen(store = store, onBack = { nav.popBackStack() })
+                        SettingsScreen(store = store, onBack = { nav.popBackStack() }, onOpenProfiles = { nav.navigate("profiles") })
+                    }
+
+                    composable("profiles") {
+                        ProfileManagerScreen(onBack = { nav.popBackStack() })
                     }
                 }
             }

--- a/app/src/main/java/com/chris/m3usuite/ui/auth/ProfileGate.kt
+++ b/app/src/main/java/com/chris/m3usuite/ui/auth/ProfileGate.kt
@@ -1,0 +1,110 @@
+package com.chris.m3usuite.ui.auth
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import com.chris.m3usuite.data.db.DbProvider
+import com.chris.m3usuite.data.db.Profile
+import com.chris.m3usuite.prefs.SettingsStore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.first
+import java.security.MessageDigest
+
+@Composable
+fun ProfileGate(
+    onEnter: () -> Unit,
+) {
+    val ctx = androidx.compose.ui.platform.LocalContext.current
+    val store = remember { SettingsStore(ctx) }
+    val db = remember { DbProvider.get(ctx) }
+    val scope = rememberCoroutineScope()
+
+    var adult by remember { mutableStateOf<Profile?>(null) }
+    var kids by remember { mutableStateOf<List<Profile>>(emptyList()) }
+
+    // PIN UI state
+    var showPin by remember { mutableStateOf(false) }
+    var setPin by remember { mutableStateOf(false) }
+    var pin by remember { mutableStateOf("") }
+    var pin2 by remember { mutableStateOf("") }
+    var pinError by remember { mutableStateOf<String?>(null) }
+    val pinSet by store.adultPinSet.collectAsState(initial = false)
+
+    LaunchedEffect(Unit) {
+        val list = withContext(Dispatchers.IO) { db.profileDao().all() }
+        adult = list.firstOrNull { it.type == "adult" }
+        kids = list.filter { it.type == "kid" }
+        // if a current profile is set, skip gate
+        val cur = store.currentProfileId.first()
+        if (cur > 0) onEnter()
+    }
+
+    fun sha256(s: String): String {
+        val md = MessageDigest.getInstance("SHA-256")
+        val dig = md.digest(s.toByteArray())
+        return dig.joinToString("") { b -> "%02x".format(b) }
+    }
+
+    @Composable
+    fun PinDialog(onDismiss: () -> Unit) {
+        AlertDialog(
+            onDismissRequest = onDismiss,
+            title = { Text(if (setPin) "PIN festlegen" else "PIN eingeben") },
+            text = {
+                Column {
+                    OutlinedTextField(value = pin, onValueChange = { pin = it }, label = { Text("PIN") }, singleLine = true, visualTransformation = PasswordVisualTransformation())
+                    if (setPin) {
+                        Spacer(Modifier.height(8.dp))
+                        OutlinedTextField(value = pin2, onValueChange = { pin2 = it }, label = { Text("PIN wiederholen") }, singleLine = true, visualTransformation = PasswordVisualTransformation())
+                    }
+                    pinError?.let { Text(it, color = MaterialTheme.colorScheme.error) }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    if (setPin) {
+                        if (pin.isBlank() || pin != pin2) { pinError = "PINs stimmen nicht"; return@TextButton }
+                        val h = sha256(pin)
+                        scope.launch { store.setAdultPinHash(h); store.setAdultPinSet(true); pin = ""; pin2 = ""; showPin = false; onEnter() }
+                    } else {
+                        scope.launch {
+                            val ok = sha256(pin) == store.adultPinHash.first()
+                            if (ok) { pin = ""; showPin = false; onEnter() } else pinError = "Falscher PIN"
+                        }
+                    }
+                }) { Text("OK") }
+            },
+            dismissButton = { TextButton(onClick = onDismiss) { Text("Abbrechen") } }
+        )
+    }
+
+    Column(Modifier.fillMaxSize().padding(16.dp)) {
+        Text("Wer bist du?", style = MaterialTheme.typography.titleLarge)
+        Spacer(Modifier.height(12.dp))
+        // Adult
+        OutlinedCard(Modifier.fillMaxWidth().clickable {
+            if (!pinSet) { setPin = true; pin = ""; pin2 = ""; pinError = null; showPin = true }
+            else { setPin = false; pin = ""; pinError = null; showPin = true }
+            scope.launch { store.setCurrentProfileId(adult?.id ?: -1) }
+        }) { ListItem(headlineContent = { Text("Ich bin Erwachsen") }, supportingContent = { Text("Mit PIN geschützt") }) }
+        Spacer(Modifier.height(16.dp))
+        Text("Ich bin ein Kind", style = MaterialTheme.typography.titleMedium)
+        LazyColumn(contentPadding = PaddingValues(vertical = 8.dp)) {
+            items(kids, key = { it.id }) { k ->
+                OutlinedCard(Modifier.fillMaxWidth().padding(vertical = 4.dp).clickable {
+                    scope.launch { store.setCurrentProfileId(k.id); onEnter() }
+                }) { ListItem(headlineContent = { Text(k.name) }, supportingContent = { Text("Kinderprofil") }) }
+            }
+        }
+    }
+
+    if (showPin) PinDialog(onDismiss = { showPin = false })
+}

--- a/app/src/main/java/com/chris/m3usuite/ui/profile/ProfileManagerScreen.kt
+++ b/app/src/main/java/com/chris/m3usuite/ui/profile/ProfileManagerScreen.kt
@@ -1,0 +1,90 @@
+package com.chris.m3usuite.ui.profile
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.chris.m3usuite.data.db.DbProvider
+import com.chris.m3usuite.data.db.Profile
+import com.chris.m3usuite.data.repo.ScreenTimeRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.launch
+import androidx.compose.ui.Alignment
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ProfileManagerScreen(onBack: () -> Unit) {
+    val ctx = androidx.compose.ui.platform.LocalContext.current
+    val db = remember { DbProvider.get(ctx) }
+    val scope = rememberCoroutineScope()
+    val screenRepo = remember { ScreenTimeRepository(ctx) }
+
+    var kids by remember { mutableStateOf<List<Profile>>(emptyList()) }
+    var newKidName by remember { mutableStateOf("") }
+
+    suspend fun load() {
+        kids = withContext(Dispatchers.IO) { db.profileDao().all().filter { it.type == "kid" } }
+    }
+
+    LaunchedEffect(Unit) { load() }
+
+    Scaffold(topBar = {
+        TopAppBar(title = { Text("Profile verwalten") }, navigationIcon = {
+            IconButton(onClick = onBack) { Icon(painter = androidx.compose.ui.res.painterResource(android.R.drawable.ic_menu_revert), contentDescription = "Zurück") }
+        })
+    }) { pad ->
+        Column(Modifier.fillMaxSize().padding(pad).padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            OutlinedTextField(value = newKidName, onValueChange = { newKidName = it }, label = { Text("Neues Kinderprofil") })
+            Button(onClick = {
+                scope.launch(Dispatchers.IO) {
+                    val now = System.currentTimeMillis()
+                    db.profileDao().insert(Profile(name = newKidName.ifBlank { "Kind" }, type = "kid", avatarPath = null, createdAt = now, updatedAt = now))
+                    newKidName = ""
+                    load()
+                }
+            }, enabled = newKidName.isNotBlank()) { Text("Anlegen") }
+
+            Divider()
+
+            LazyColumn(contentPadding = PaddingValues(bottom = 24.dp)) {
+                items(kids, key = { it.id }) { kid ->
+                    var name by remember(kid.id) { mutableStateOf(kid.name) }
+                    var limit by remember(kid.id) { mutableStateOf(60) }
+                    OutlinedCard(Modifier.fillMaxWidth()) {
+                        Column(Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                            OutlinedTextField(value = name, onValueChange = { name = it }, label = { Text("Name") })
+                            Row(verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
+                                Text("Tageslimit (Minuten)", modifier = Modifier.weight(1f))
+                                Slider(value = limit.toFloat(), valueRange = 0f..240f, onValueChange = { limit = it.toInt() })
+                                Text("${limit}")
+                            }
+                            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                Button(onClick = {
+                                    scope.launch(Dispatchers.IO) {
+                                        db.profileDao().update(kid.copy(name = name, updatedAt = System.currentTimeMillis()))
+                                        // apply today's limit
+                                        screenRepo.setDailyLimit(kid.id, limit)
+                                        load()
+                                    }
+                                }) { Text("Speichern") }
+                                TextButton(onClick = {
+                                    scope.launch(Dispatchers.IO) {
+                                        db.profileDao().delete(kid)
+                                        load()
+                                    }
+                                }) { Text("Löschen") }
+                            }
+                        }
+                    }
+                    Spacer(Modifier.height(8.dp))
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/chris/m3usuite/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/chris/m3usuite/ui/screens/SettingsScreen.kt
@@ -25,7 +25,8 @@ import kotlinx.coroutines.launch
 @Composable
 fun SettingsScreen(
     store: SettingsStore,
-    onBack: () -> Unit
+    onBack: () -> Unit,
+    onOpenProfiles: (() -> Unit)? = null
 ) {
     val scope = rememberCoroutineScope()
     val mode by store.playerMode.collectAsState(initial = "ask")
@@ -53,6 +54,9 @@ fun SettingsScreen(
         }
     ) { padding ->
         Column(Modifier.fillMaxSize().padding(padding).padding(16.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+            if (onOpenProfiles != null) {
+                TextButton(onClick = onOpenProfiles) { Text("Profile verwalten…") }
+            }
             Text("Player", style = MaterialTheme.typography.titleMedium)
             Column {
                 Radio("Immer fragen", mode == "ask") { scope.launch { store.setPlayerMode("ask") } }


### PR DESCRIPTION
Adds ProfileGate (Adult PIN + kids selection) and ProfileManager (create/rename/delete kids, set daily screen-time limit). Integrates routes in MainActivity and link from Settings. Build passes.\n\n- Gate: if current profile set, auto-enters Library; otherwise choose Adult (PIN) or Kid.\n- PIN: set-on-first-use or verify if already set (SHA-256).\n- Manager: list kids, create new, rename, delete; set today's screen-time limit via repository.\n- Workers: daily screen-time reset worker already scheduled in MainActivity.\n\nNo changes to EPG/Xtream or player routes.