### PR TITLE
phase-9 UX: detail grants + haptics; finalize roadmap

### DIFF
--- a/app/src/main/java/com/chris/m3usuite/ui/components/ResumeCarousel.kt
+++ b/app/src/main/java/com/chris/m3usuite/ui/components/ResumeCarousel.kt
@@ -31,6 +31,10 @@ import com.chris.m3usuite.data.db.ResumeVodView
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import com.chris.m3usuite.prefs.SettingsStore
+import kotlinx.coroutines.flow.first
 
 // resume-ui: Phase 3 – Resume-Karusselle (ohne Bilder), Material (nicht Material3)
 
@@ -71,6 +75,7 @@ fun ResumeSectionAuto(
     }
 
     val scope = rememberCoroutineScope()
+    // rows keep simple; haptics handled inside ResumeCard per onLongClick
 
     Column(modifier = Modifier.fillMaxWidth()) {
         if (chooserItem != null) {
@@ -210,11 +215,18 @@ private fun ResumeCard(
     onPlay: () -> Unit,
     onClear: () -> Unit
 ) {
+    val ctx = LocalContext.current
+    val haptics = androidx.compose.ui.platform.LocalHapticFeedback.current
+    var hEnabled by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) { hEnabled = SettingsStore(ctx).hapticsEnabled.first() }
     Card(
         modifier = Modifier
             .width(200.dp)
             .height(140.dp)
-            .combinedClickable(onClick = onPlay, onLongClick = onClear)
+            .combinedClickable(onClick = onPlay, onLongClick = {
+                if (hEnabled) haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                onClear()
+            })
     ) {
         Column(
             modifier = Modifier

--- a/app/src/main/java/com/chris/m3usuite/ui/screens/LibraryScreen.kt
+++ b/app/src/main/java/com/chris/m3usuite/ui/screens/LibraryScreen.kt
@@ -46,6 +46,8 @@ import androidx.navigation.NavHostController
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import com.chris.m3usuite.data.db.Profile
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
@@ -64,6 +66,8 @@ fun LibraryScreen(
     val tv = isTv(ctx)
     val focus = LocalFocusManager.current
     val headers = rememberImageHeaders()
+    val haptics = LocalHapticFeedback.current
+    val hapticsEnabled by store.hapticsEnabled.collectAsState(initial = false)
 
     var tab by rememberSaveable { mutableIntStateOf(0) }
     val tabs = listOf("Live", "VOD", "Series", "Alle")
@@ -338,6 +342,7 @@ fun LibraryScreen(
                             if (selectionMode) {
                                 val key = mi.id to mi.type
                                 selected = if (key in selected) selected - key else selected + key
+                                if (hapticsEnabled) haptics.performHapticFeedback(HapticFeedbackType.LongPress)
                             } else {
                                 when (mi.type) {
                                     "live" -> openLive(mi.id)
@@ -362,6 +367,7 @@ fun LibraryScreen(
                             if (selectionMode) {
                                 val key = id to "live"
                                 selected = if (key in selected) selected - key else selected + key
+                                if (hapticsEnabled) haptics.performHapticFeedback(HapticFeedbackType.LongPress)
                             } else openLive(id)
                         }
                     )


### PR DESCRIPTION
Improvements\n- Detail screens (Live/VOD/Series): add Adult-only grant/remove to kids via bottom sheets (multi-select).\n- Haptics: basic feedback for selection toggles and resume long-press, honoring Settings toggle.\n- Build green.\n\nNotes\n- PIN gate + manager, autoplay, filters, and resets already merged/pending in earlier PRs.